### PR TITLE
Compatibility with Python3.12

### DIFF
--- a/FirmXRay/README.md
+++ b/FirmXRay/README.md
@@ -125,6 +125,45 @@ There is another running example for TI, and you can try it with
 make run PATH=examples/TI/oad.bin MCU=TI
 ```
 
+
+## Build Ghidra JAR from Source (In Case Download Link Become Invalid)
+
+If the download links are broken, you can build Ghidra JAR from source:
+
+**Prerequisites:**
+- Java 21 (OpenJDK recommended)
+- Git
+- Build tools (make, gcc, etc.)
+
+**Step-by-step compilation:**
+
+```shell
+# 1. Clone the Ghidra repository
+git clone https://github.com/NationalSecurityAgency/ghidra.git
+cd ghidra
+
+# 2. (Optional) Checkout the specific commit tested in this project (Ghidra 11.5 DEV)
+git checkout a09bd1ee34
+
+# 3. Download dependencies
+./gradlew --init-script gradle/support/fetchDependencies.gradle
+
+# 4. Build Ghidra distribution
+./gradlew buildGhidra
+
+# 5. The built distribution will be located at:
+# build/dist/ghidra_11.5_DEV/
+
+# 6. Set environment variable
+export GHIDRA_INSTALL_DIR=./build/dist/ghidra_11.5_DEV
+
+# 7. Optional: Create a portable JAR file
+cd build/dist/ghidra_11.5_DEV
+./support/buildGhidraJar
+# This creates ghidra.jar (221MB) for headless operations
+```
+
+
 ## Citation
 
 If you create a research work that uses our work, please cite our paper:

--- a/binwalk/src/binwalk/core/magic.py
+++ b/binwalk/src/binwalk/core/magic.py
@@ -428,7 +428,7 @@ class Magic(object):
         # Regex rule to find format strings
         self.fmtstr = re.compile("%[^%]")
         # Regex rule to find periods (see self._do_math)
-        self.period = re.compile("\.")
+        self.period = re.compile(r"\.")
 
     def reset(self):
         self.display_once = set()

--- a/binwalk/src/binwalk/core/module.py
+++ b/binwalk/src/binwalk/core/module.py
@@ -704,14 +704,16 @@ class Modules(object):
                 modules[module] = module.PRIORITY
 
         # user-defined modules
-        import imp
+        import importlib.util
         user_modules = binwalk.core.settings.Settings().user.modules
         for file_name in os.listdir(user_modules):
             if not file_name.endswith('.py'):
                 continue
             module_name = file_name[:-3]
             try:
-                user_module = imp.load_source(module_name, os.path.join(user_modules, file_name))
+                spec = importlib.util.spec_from_file_location(module_name, os.path.join(user_modules, file_name))
+                user_module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(user_module)
             except KeyboardInterrupt as e:
                 raise e
             except Exception as e:

--- a/binwalk/src/binwalk/core/plugin.py
+++ b/binwalk/src/binwalk/core/plugin.py
@@ -1,7 +1,7 @@
 # Core code for supporting and managing plugins.
 
 import os
-import imp
+import importlib.util
 import inspect
 import binwalk.core.common
 import binwalk.core.settings
@@ -180,7 +180,9 @@ class Plugins(object):
                         module = file_name[:-len(self.MODULE_EXTENSION)]
 
                         try:
-                            plugin = imp.load_source(module, os.path.join(plugins[key]['path'], file_name))
+                            spec = importlib.util.spec_from_file_location(module, os.path.join(plugins[key]['path'], file_name))
+                            plugin = importlib.util.module_from_spec(spec)
+                            spec.loader.exec_module(plugin)
                             plugin_class = self._find_plugin_class(plugin)
 
                             plugins[key]['enabled'][module] = True
@@ -222,7 +224,9 @@ class Plugins(object):
                 continue
 
             try:
-                plugin = imp.load_source(module, file_path)
+                spec = importlib.util.spec_from_file_location(module, file_path)
+                plugin = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(plugin)
                 plugin_class = self._find_plugin_class(plugin)
 
                 class_instance = plugin_class(self.parent)


### PR DESCRIPTION
This pull request introduces several updates to improve code maintainability and functionality. Key changes include enhancing documentation with detailed build instructions, updating deprecated Python imports, and modernizing plugin and module handling.

### Documentation Enhancements:
* Added a new section in `FirmXRay/README.md` with step-by-step instructions for building the Ghidra JAR from source, including prerequisites, commands, and environment setup. This ensures users can build the JAR if the download links become invalid.

### Code Modernization:
* Replaced the deprecated `imp` module with `importlib.util` for loading user-defined modules and plugins in `binwalk`. This change affects multiple files:
  - [`binwalk/src/binwalk/core/module.py`](diffhunk://#diff-a06b5e43e28e3a7498e0b5e7c316b85c5c4b672ddea9713f115fd5a1838519e1L707-R716): Updated the logic for loading user-defined modules using `importlib.util`.
  - [`binwalk/src/binwalk/core/plugin.py`](diffhunk://#diff-1708972d6aad66fd6eb33639d72644537c5f7816724b3ddf1dc7eb9837e96fe4L183-R185): Modernized plugin loading in methods like `list_plugins` and `_load_plugin_modules`. [[1]](diffhunk://#diff-1708972d6aad66fd6eb33639d72644537c5f7816724b3ddf1dc7eb9837e96fe4L183-R185) [[2]](diffhunk://#diff-1708972d6aad66fd6eb33639d72644537c5f7816724b3ddf1dc7eb9837e96fe4L225-R229) [[3]](diffhunk://#diff-1708972d6aad66fd6eb33639d72644537c5f7816724b3ddf1dc7eb9837e96fe4L4-R4)

### Bug Fix:
* Fixed a regex pattern in `binwalk/src/binwalk/core/magic.py` by adding a raw string (`r"\."`) to correctly escape the period character.